### PR TITLE
More reliable way to see if we have any FK info yet - in Java1.8 on OSX ...

### DIFF
--- a/hbnpojogen-core/src/main/java/com/felees/hbnpojogen/Core.java
+++ b/hbnpojogen-core/src/main/java/com/felees/hbnpojogen/Core.java
@@ -429,7 +429,7 @@ public class Core {
 					}
 				}
 
-				if (keySeq == 1) { // first instance
+				if (tableObj.getImportedKeys().get(fkName) == null) { // first instance
 					tableObj.getImportedKeys().put(fkName,
 							new KeyObj(fkColName, State.getInstance().tables.get(pkFullTableName).getName(), pkTableCat, pkTableSchema, pkColName));
 				}


### PR DESCRIPTION
I was getting NullPointer exceptions in step 3) Parsing tables

After investigation I found that the composite keys were being looped over without explicit regard for the keySeq itself, yet the code seemed to rely on keySeq==1 coming first.

On my version of java this was NOT the case, keySeq==2 was coming up first.  

This change got me past my issue.

Java Version
java version "1.8.0_25"
Java(TM) SE Runtime Environment (build 1.8.0_25-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.25-b02, mixed mode)